### PR TITLE
Add "3-clause bsd" varient

### DIFF
--- a/liccheck-server.cfg
+++ b/liccheck-server.cfg
@@ -4,6 +4,7 @@ authorized_licenses:
         new bsd
         bsd license
         bsd-3-clause
+        3-clause bsd
         new bsd license
         simplified bsd
         apache


### PR DESCRIPTION
The `bsd-3-clause` has a couple of different spellings, such as the `3-clause bsd`. We wanted to use one such license, so here we are.