### PR TITLE
Config file start for pycodestyle

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
It's not hard to enable in a project, but it seemed a tad slow. PyCharm automatically uses pycodestyle and/or pep8 by default and it complains that the code we write in VSCode shows up with style errors. I don't mind the extra style rules.

It might be worth a separate conversation to use black, pycodestyle, or pylint, but for now, this is a start to at least bring something to the table that aligns both editors a little more.

`poetry add -D pycodestyle`

add these options to your `.vscode/settings.json`

```    "python.linting.pycodestyleEnabled": false,
    "python.linting.pycodestylePath": "${workspaceFolder}/.venv/bin/pycodestyle",
    "python.linting.pycodestyleArgs": [
        "--config=.ml-python-configs/.pycodestyle"
    ],```